### PR TITLE
View bets templates

### DIFF
--- a/views/bet.handlebars
+++ b/views/bet.handlebars
@@ -1,0 +1,10 @@
+<!--View single bet.-->
+
+<!--A Row to display the single result-->
+<div class="row">
+
+	<div class="col-md-12">
+		<!-- Display 'bet card' here-->
+			{{> view-bets/bet-block}}
+	</div>
+</div>

--- a/views/bets.handlebars
+++ b/views/bets.handlebars
@@ -1,3 +1,6 @@
+<!--View multiple bets-->
+<!--including all bets (sports, popular, fun, work etc), filtered bets, my bets-->
+
 <!--A Row for the filters.-->
 <div class="row">
 	<div class="col-md-12">

--- a/views/bets.handlebars
+++ b/views/bets.handlebars
@@ -1,0 +1,25 @@
+<!--A Row for the filters.-->
+<div class="row">
+	<div class="col-md-12">
+		<p>Filters: #sports #fun #work #popular #etc #etc</p>
+	</div>
+</div>
+
+<!--A Row to display all of the results-->
+<div class="row">
+	<!-- If layout option one, split this into two columns.-->
+
+	<div class="col-md-12">
+	<!-- Display each 'bet card' here-->
+			{{#each data}}
+				{{> view-bets/bet-block}}
+			{{/each}}
+	</div>
+</div>
+
+<!-- Add the pagination below -->
+<div class="row">
+	<div class="col-md-12">
+		<p>1 2 3 4 5 6 7 8 9 10</p>
+	</div>
+</div>

--- a/views/partials/view-bets/bet-block.handlebars
+++ b/views/partials/view-bets/bet-block.handlebars
@@ -1,0 +1,61 @@
+<div class="card">
+	<div class="card-body">
+		<div class="row">
+
+			<!-- the left side of the bet card -->
+			<div class="col-md-4">
+				<div class="row">
+					<div class="col-md-4">
+						vote thumb and
+
+						<button type="button" class="btn btn-primary">
+							30 points
+						</button>
+
+						<span class="badge rounded-pill bg-warning text-dark">upvotes</span>
+					</div>
+					<div class="col-md-4">
+						<p>Adrian bet he can watch the entire netflix catalogue in year.</p>
+					</div>
+					<div class="col-md-4">
+						<span class="badge rounded-pill bg-light text-dark">
+							avatar and name
+						</span>
+					</div>
+				</div>
+			</div>
+
+			<!-- the centre of the bet card -->
+			<div class="col-md-2">
+				<div class="row">
+					<div class="col-md-12">
+						Big V
+						and then
+					</div>
+				</div>
+			</div>
+
+			<!-- the right side of the bet card.-->
+			<div class="col-md-4">
+				<div class="row">
+					<div class="col-md-4">
+						<span class="badge rounded-pill bg-light text-dark">
+							avatar and name
+						</span>
+					</div>
+
+					<div class="col-md-4">
+						<p>This bet is pending.</p>
+					</div>
+
+					<div class="col-md-4">
+						vote thumb and
+						<span class="badge rounded-pill bg-warning text-dark">upvotes</span>
+					</div>
+
+				</div>
+			</div>
+
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Added basic reusable templates for displaying multiple bets, and single bets.
Multiple bets == All bets, filtered bets (sports, fun work, popular), my bets.

Still require modification once data is available - and require specifics ie buttons, links and so on.

Bet card can be recycled on front page provided info is the same.

Loosely based on 
![image](https://user-images.githubusercontent.com/3242587/109629821-29b47280-7b94-11eb-9ecd-f3926c653a0a.png)
