### PR TITLE
Change bet status to expired if 'expires' is the the past and status is not 2 (expired)

### DIFF
--- a/helpers/expirationcheck.js
+++ b/helpers/expirationcheck.js
@@ -1,4 +1,25 @@
-module.exports = () => {
-  // TODO: Add logic to check for bets which have passed their expiry date/time and mark them as ended.
-  console.log("Checking for any bets that have expired....");
+const db = require("../models");
+const { Op } = require("sequelize");
+
+module.exports = async () => {
+  const expiredBets = await db.Bet.update(
+    { status: 2 },
+    {
+      where: {
+        status: {
+          [Op.ne]: 2
+        },
+        expires: {
+          [Op.lt]: new Date()
+        }
+      }
+    }
+  );
+
+  const affectedRows = expiredBets[0];
+  if (affectedRows) {
+    console.log(`Bets set to expired: ${affectedRows}`);
+  }
+
+  // TODO: Get all of the affected rows and then send out emails informing that the bet has reached it's expiry.
 };


### PR DESCRIPTION
TODO:  Send out an email to all affected bet recipients informing them that the bet has reached its expiry.